### PR TITLE
Upgrade elm-css to address non-existent murmur3 dependency

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -13,10 +13,9 @@
       "elm/url": "1.0.0",
       "elm-explorations/markdown": "1.0.0",
       "krisajenkins/remotedata": "6.0.1",
-      "rtfeldman/elm-css": "16.0.1"
+      "rtfeldman/elm-css": "16.1.1"
     },
     "indirect": {
-      "Skinney/murmur3": "2.0.8",
       "elm/bytes": "1.0.8",
       "elm/file": "1.0.5",
       "elm/time": "1.0.0",


### PR DESCRIPTION
The murmur3 indirect dependency was transferred to [another author](https://github.com/robinheghan/murmur3/), but the tags are completely off. To sidestep this, [the elm-css project now includes the relevant functionality](https://github.com/rtfeldman/elm-css/commit/466e0c9b2997b1ae3f5228049456d65ce8f0a6cd).